### PR TITLE
Updated Keleres, Muaat, and Mentak commanders with unlock edge and corner case info

### DIFF
--- a/F_keleres.php
+++ b/F_keleres.php
@@ -85,6 +85,7 @@
     <ol class="note">
     <li>The trade good to unlock Suffi An is spent after, and independent of, any trade goods spent while resolving the action card.</li>
     <li>If the Keleres player uses their additional action to perform another component action, they may perform another additional action. They may do this any number of times.</li>
+    <li>Suffi An does not trigger from the action card used to unlock her, and thus that specific action card does not grant an additional action.</li>
     </ol>
 
 <h1>Harka Leeds &mdash; Erwan&rsquo;s Covenant <sub>(Hero)</sub></h1>

--- a/F_keleres.php
+++ b/F_keleres.php
@@ -85,7 +85,7 @@
     <ol class="note">
     <li>The trade good to unlock Suffi An is spent after, and independent of, any trade goods spent while resolving the action card.</li>
     <li>If the Keleres player uses their additional action to perform another component action, they may perform another additional action. They may do this any number of times.</li>
-    <li>Suffi An does not trigger from the action card used to unlock her, and thus that specific action card does not grant an additional action.</li>
+    <li>Suffi An does not trigger from the action card used to unlock her. This means that the action that unlocks Suffi An does not provide an additional action.</li>
     </ol>
 
 <h1>Harka Leeds &mdash; Erwan&rsquo;s Covenant <sub>(Hero)</sub></h1>

--- a/F_mentak.php
+++ b/F_mentak.php
@@ -60,6 +60,9 @@
 <h1>S&rsquo;ula Mentarion <sub>(Commander)</sub></h1>
     <ol class="note">
     <li>The Mentak player&rsquo;s opponent chooses which promissory note they give to the Mentak player.</li>
+    <li>If the Mentak player resolves their <i>Salvage Operations</i> faction technology after winning a space combat to place their fourth cruiser, their commander does not trigger for that combat.</li>
+    <li>If the Mentak player unlocks their commander during combat, for example by placing their fourth cruiser due to the effect of <i>Sleeper Cell</i>, they can use the commander at the end of that combat if they win.</li>
+    <ol><li>The four cruisers do not need to survive until the end of combat, the commander at the moment that the fourth cruiser is placed.</li></ol>
     </ol>
 
 <h1>Ipswitch, Loose Cannon &mdash; Sleeper Cell <sub>(Hero)</sub></h1>

--- a/F_muaat.php
+++ b/F_muaat.php
@@ -51,6 +51,7 @@
         <li>If the Muaat player wishes to score <i>Lead From the Front</i> and <i>Form a Spy Network</i> during the one status phase, they must do so simultaneously, and both happen before the Mentak player may use their <sc>Pillage</sc> faction ability. If the Mentak player subsequently uses their agent, Suffi An, when they use their <sc>Pillage</sc> faction ability on the trade goods the Muaat player gained from Magmus when spending the tokens for <i>Lead From the Front</i>, then the Muaat player cannot discard the drawn action card for <i>Form a Spy Network</i>.</li>
     </ol>
     <li>If the Muaat player uses the ability of the <i>Scepter of Emelpar</i> relic, they will be unable to benefit from the ability of Magmus.</li>
+    <li>The Muaat player must have their commander unlocked before spending the strategy token in order to gain the trade good. For example, if the Muaat player spends a strategy token to follow the secondary of Warfare and produces a war sun to unlock the commander, they do not gain the trade good from Magmus</li>
     </ol>
 
 <h1>Adjudicator Ba&rsquo;al &mdash; Nova Seed <sub>(Hero)</sub></h1>


### PR DESCRIPTION
Had a game recently that ran into this fun rules hole. The action card that you use to unlock the Keleres commander does not itself trigger the Keleres hero (due to weirdness with how exactly triggers work in TI).  So (ignoring interactions with Fleet Logistics and the Master Plan action card) the turn you unlock her you do not get additional actions. I figured this may be worth adding here. I tried my best to find the most concise way to phrase this here. IDK if the interactions with Fleet Logistics and Master Plan should be clarified as well...